### PR TITLE
Add handler to retrieve comment images

### DIFF
--- a/csharp/Urban.DCP.Data/Comment.cs
+++ b/csharp/Urban.DCP.Data/Comment.cs
@@ -140,6 +140,30 @@ namespace Urban.DCP.Data
             
         }
 
+        /// <summary>
+        /// Checks if a user is authorized to view a comment/image
+        /// </summary>
+        /// <param name="user"></param>
+        /// <returns></returns>
+        public bool IsAuthorizedToView(User user)
+        {
+            if (user == null && AccessLevel != CommentAccessLevel.Public) return false;
+            if (user != null && user.IsSysAdmin()) return true;
+            if (user != null)
+            {
+                switch (AccessLevel)
+                {
+                    case CommentAccessLevel.Public:
+                        return true;
+                    case CommentAccessLevel.Network:
+                        return user.IsNetworked();    
+                    case CommentAccessLevel.SameOrg:
+                        return user.Organization == AssociatedOrgId;
+                }
+            }
+            return false;
+        }
+
         public static Comment AddComment(string nlihcId, User user, 
             CommentAccessLevel level, string text, byte[] image)
         {

--- a/csharp/Urban.DCP.Handlers/CommentImageHandler.cs
+++ b/csharp/Urban.DCP.Handlers/CommentImageHandler.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Net;
+using System.Web;
+using Azavea.Web;
+using Azavea.Web.Handler;
+using Urban.DCP.Data;
+using System.Drawing;
+
+
+namespace Urban.DCP.Handlers
+{
+    public class CommentImageHandler : BaseHandler
+    {
+        private const int THUMB_WIDTH = 100;
+        private const int THUMB_HEIGHT = 100;
+
+        /// <summary>
+        /// For a given comment id, return the image
+        /// If there is no image associated, a 404
+        /// Expects:
+        /// id: string, comment id
+        /// thumb: bool, optional render as thumbnail
+        /// </summary>
+        protected override void InternalGET(HttpContext context, HandlerTimedCache cache)
+        {
+            var user = UserHelper.GetUser(context.User.Identity.Name);
+            var thumb = false;
+            WebUtil.ParseOptionalBoolParam(context, "thumb", ref thumb);
+            
+            // Default to 100x100 if in thumbnail mode, but can override.
+            var width = THUMB_WIDTH;
+            WebUtil.ParseOptionalIntParam(context, "w", ref width);
+            var height = THUMB_HEIGHT;
+            WebUtil.ParseOptionalIntParam(context, "h", ref height);
+
+            var id = WebUtil.ParseIntParam(context, "id");
+            try
+            {
+                var comment = Comment.ById(id);
+                if (!comment.HasPicture)
+                {
+                    throw new CommentNotFoundException();
+                }
+
+                if (comment.IsAuthorizedToView(user))
+                {
+                    context.Response.ContentType = "image/jpeg";
+                    var img = comment.Image;
+                    if (thumb)
+                    {
+                        var ms = new MemoryStream();
+                        ms.Write(img, 0, img.Length);
+                        var b = new Bitmap(ms);
+                        var thumbnail = b.GetThumbnailImage(width, height, () => false, IntPtr.Zero);
+                        var outStream = new MemoryStream();
+                        thumbnail.Save(outStream, ImageFormat.Jpeg);
+                        img = outStream.ToArray();
+                    }
+                    context.Response.BinaryWrite(img);
+                    return;
+                }
+                context.Response.StatusCode = (int) HttpStatusCode.Forbidden;
+            }
+            catch (CommentNotFoundException)
+            {
+                context.Response.StatusCode = (int) HttpStatusCode.NotFound;
+            }
+        }
+    }
+}

--- a/csharp/Urban.DCP.Handlers/Urban.DCP.Handlers.csproj
+++ b/csharp/Urban.DCP.Handlers/Urban.DCP.Handlers.csproj
@@ -125,6 +125,7 @@
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
   </ItemGroup>
@@ -132,6 +133,7 @@
     <Compile Include="AttributesHandler.cs" />
     <Compile Include="AppHealth.cs" />
     <Compile Include="CommentHandler.cs" />
+    <Compile Include="CommentImageHandler.cs" />
     <Compile Include="OrganizationHandler.cs" />
     <Compile Include="EmailConfirmationHandler.cs" />
     <Compile Include="ReportDownloadHandler.cs" />

--- a/csharp/Urban.DCP.Web/Urban.DCP.Web.csproj
+++ b/csharp/Urban.DCP.Web/Urban.DCP.Web.csproj
@@ -292,6 +292,7 @@
     <Content Include="handlers\email-confirmation.ashx" />
     <Content Include="handlers\organizations.ashx" />
     <Content Include="handlers\comments.ashx" />
+    <Content Include="handlers\comment-image.ashx" />
     <None Include="minifier.conf" />
     <Content Include="packages.config" />
   </ItemGroup>

--- a/csharp/Urban.DCP.Web/handlers/comment-image.ashx
+++ b/csharp/Urban.DCP.Web/handlers/comment-image.ashx
@@ -1,0 +1,1 @@
+﻿<%@ WebHandler Language="C#" Class="Urban.DCP.Handlers.CommentImageHandler" %>


### PR DESCRIPTION
Images are stored in the DB and are not serialized with comment
responses.
This handler will return an image or thumbnail image for a given comment
id
