### PR TITLE
Feature to allow admin to upload Attribute tables

### DIFF
--- a/csharp/Urban.DCP.Data/PDB/PdbAttribute.cs
+++ b/csharp/Urban.DCP.Data/PDB/PdbAttribute.cs
@@ -1,6 +1,11 @@
 using Azavea.Open.Common;
-
+using Azavea.Open.DAO.SQL;
+using FileHelpers;
+using System;
+using System.IO;
+using Urban.DCP.Data.Uploadable;
 namespace Urban.DCP.Data.PDB
+
 {
     /// <summary>
     /// Represents a single attribute from the PDP data, that lives in
@@ -173,5 +178,7 @@ namespace Urban.DCP.Data.PDB
             }
             return retVal;
         }
+
+       
     }
 }

--- a/csharp/Urban.DCP.Data/PDB/PdbAttributesHelper.cs
+++ b/csharp/Urban.DCP.Data/PDB/PdbAttributesHelper.cs
@@ -18,6 +18,12 @@ namespace Urban.DCP.Data.PDB
         private static readonly Azavea.Database.FastDAO<PdbAttributeValue> _attrValDao =
             new Azavea.Database.FastDAO<PdbAttributeValue>(Config.GetConfig("PDP.Data"), "PDB");
 
+        public static Azavea.Database.FastDAO<PdbAttribute> getAttrDao()
+        {
+            return _attrDao;
+        }
+
+
         /// <summary>
         /// Returns the metadata about the attributes that are columns on the primary
         /// table.  Does not include the allowed values for those columns that have them.

--- a/csharp/Urban.DCP.Data/Uploadable/AttributeUploadable.cs
+++ b/csharp/Urban.DCP.Data/Uploadable/AttributeUploadable.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using FileHelpers;
+using System.IO;
+using Urban.DCP.Data.Uploadable;
+using Urban.DCP.Data.PDB;
+using Azavea.Open.DAO.SQL;
+
+namespace Urban.DCP.Data.Uploadable
+{
+    [DelimitedRecord(",")]
+    [IgnoreFirst(1)]
+    public class AttributeUploadable
+    
+    {
+        public String Entity;
+        public String Attribute;
+        public int? IsFilter; 
+        public String OrderWithinCategory; 
+        public String Category;
+        public String CategoryOrder;
+        public String SubCategory; 
+        public String OrderWithinSubCategory;
+        public int? IsNative; 
+        public String TableDisplayName;
+        public String FilterDisplayName;
+        public String Description;
+        public String UiType;
+        public String ValueType;
+        public int? MinValue; 
+        public int? MaxValue;
+        public int? GroupBy;
+        public String RequiredRole;
+        public int? DefaultTableDisplay;
+        public int? TableColumnOrder;
+        public int? ShortViewOrder; 
+        public String LongViewOrder;
+        public String Difficulty;
+   
+        public static ImportResult<AttributeUploadable> LoadAttributes(Stream data)
+        {
+            var engine = new FileHelperEngine<AttributeUploadable> { ErrorMode = ErrorMode.SaveAndContinue };
+            var attributes = engine.ReadStream(new StreamReader(data));
+            var results = new ImportResult<AttributeUploadable> { Records = attributes, Errors = engine.ErrorManager };
+
+            var _attrDao = PdbAttributesHelper.getAttrDao();
+
+            if (results.Errors.ErrorCount == 0)
+            {
+                var trans = new SqlTransaction((AbstractSqlConnectionDescriptor) _attrDao.ConnDesc);
+                try
+                {
+                    _attrDao.DeleteAll(trans);
+                    foreach (var r in results.Records) 
+                    {
+                        var newAttrRecord = MapUploadAttributeRecordToPdbAttribute(r);
+                        _attrDao.Insert(trans, newAttrRecord);
+                    }                
+                    trans.Commit();
+                }
+                catch (Exception)
+                {
+                    trans.Rollback();
+                    throw;
+                }
+
+            }
+            return results;
+        }
+
+
+        // There didn't seem to be fine grained controls over CSV order, and field inclusion/exclusion
+        // in FileHelper, so it wasn't immediately obvious how to just parse into a PdbAttribute dao model
+        // directly.  
+        public static PdbAttribute MapUploadAttributeRecordToPdbAttribute(AttributeUploadable upload) {
+            var daoModel =  new PdbAttribute();
+            daoModel.EntityType = (PdbEntityType) Enum.Parse(typeof (PdbEntityType), upload.Entity);
+            daoModel.Name = upload.Attribute;
+            daoModel.AllowFiltering = upload.IsFilter == 1 ? true : false;
+            daoModel.Category = upload.Category;
+            daoModel.SubCategory = upload.SubCategory;
+            daoModel.FilterCatOrder = upload.CategoryOrder;
+            daoModel.FilterSubCatOrder = upload.OrderWithinSubCategory;
+            daoModel.FilterAttrOrder = upload.OrderWithinCategory;
+            daoModel.InPrimaryTable = upload.IsNative == 1 ? true : false;
+            daoModel.DisplayName = upload.TableDisplayName;
+            daoModel.FilterName = upload.FilterDisplayName;
+            daoModel.Description = upload.Description;
+            if (upload.UiType != null && upload.UiType != "")
+            {
+                daoModel.UiType = (PdbUiType)Enum.Parse(typeof(PdbUiType), upload.UiType);
+            }
+            if (upload.ValueType != null)
+            {
+                daoModel.ValueType = (PdbValueType)Enum.Parse(typeof(PdbValueType), upload.ValueType);
+            }
+            daoModel.MinValue = upload.MinValue;
+            daoModel.MaxValue = upload.MaxValue;
+            daoModel.AllowGroupBy = upload.GroupBy == 1 ? true : false;
+            daoModel.RequiredRole = (SecurityRole)Enum.Parse(typeof(SecurityRole), upload.RequiredRole);
+            daoModel.ShowByDefault = upload.DefaultTableDisplay == 1 ? true : false;
+            daoModel.LongViewOrder = upload.LongViewOrder;
+            daoModel.Difficulty = (PdbDifficulty)Enum.Parse(typeof(PdbDifficulty), upload.Difficulty);
+
+            return daoModel;
+        }
+    }
+}
+

--- a/csharp/Urban.DCP.Data/Uploadable/UploadTypes.cs
+++ b/csharp/Urban.DCP.Data/Uploadable/UploadTypes.cs
@@ -2,6 +2,7 @@
 {
     public enum UploadTypes
     {
-        Project
+        Project,
+        Attribute
     }
 }

--- a/csharp/Urban.DCP.Data/Urban.DCP.Data.csproj
+++ b/csharp/Urban.DCP.Data/Urban.DCP.Data.csproj
@@ -147,6 +147,7 @@
     <Compile Include="PropertyCommentInfo.cs" />
     <Compile Include="Tests\CommentTests.cs" />
     <Compile Include="UiComment.cs" />
+    <Compile Include="Uploadable\AttributeUploadable.cs" />
     <Compile Include="Uploadable\ImportResult.cs" />
     <Compile Include="Uploadable\Project.cs" />
     <Compile Include="ResultsWithMetadata.cs" />

--- a/csharp/Urban.DCP.Web/admin/data.aspx
+++ b/csharp/Urban.DCP.Web/admin/data.aspx
@@ -7,7 +7,10 @@
      <div id="pdp-main">
          <form id="upload" method="POST" enctype="multipart/form-data">
              <input id="dataset" name="dataset" type="file"/>
-             <input id="type" name="type" type="text" value="project"/>
+             <select id="type" name="type">
+                 <option value="project">project</option>
+                 <option value="attribute">attributes</option>
+             </select>
              <input type="submit" value="Upload"/>
          </form>
          

--- a/csharp/Urban.DCP.Web/admin/data.aspx.cs
+++ b/csharp/Urban.DCP.Web/admin/data.aspx.cs
@@ -48,7 +48,11 @@ namespace Urban.DCP.Web.admin
                         errors = import.Errors;
                         added = import.Records.Length;
                         break;
-
+                    case UploadTypes.Attribute:
+                        var attrImport = AttributeUploadable.LoadAttributes(context.Request.Files[0].InputStream);
+                        errors = attrImport.Errors;
+                        added = attrImport.Records.Length;
+                        break;
                     default:
                         resultLabel.Text = String.Format("{0} is not a valid upload type.", uploadType);
                         break;


### PR DESCRIPTION
There didn't seem to be fine grained controls over CSV order, and field inclusion/exclusion
in FileHelper, so it wasn't immediately obvious how to just parse into a PdbAttribute dao model
directly. (see this comment in context below.)  
