### PR TITLE
View child records for project by role

### DIFF
--- a/csharp/Urban.DCP.Data/SecurityRole.cs
+++ b/csharp/Urban.DCP.Data/SecurityRole.cs
@@ -14,13 +14,13 @@ namespace Urban.DCP.Data
         /// </summary>
         limited = 2,
         /// <summary>
-        /// SysAdmin users have access to everything.
-        /// </summary>
-        SysAdmin = 4,//0x7FFFFFFF
-        /// <summary>
         /// Network users are assigned to a recognized organization
         /// and may have special permissions.
         /// </summary>
-        Network = 5
+        network = 4,
+        /// <summary>
+        /// SysAdmin users have access to everything.
+        /// </summary>
+        SysAdmin = 8
     }
 }

--- a/csharp/Urban.DCP.Data/Tests/ChildDisplayTests.cs
+++ b/csharp/Urban.DCP.Data/Tests/ChildDisplayTests.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using Azavea.Database;
+using Azavea.Open.Common;
+using NUnit.Framework;
+using Urban.DCP.Data.Uploadable;
+using Urban.DCP.Data.Uploadable.Display;
+
+namespace Urban.DCP.Data.Tests
+{
+    public class TestRowHolderByRole
+    {
+        public IList<Reac> pub;
+        public IList<Reac> lim;
+        public IList<Reac> net;
+    }
+
+    [TestFixture]
+    public class ChildDisplayTests
+    {
+        private static readonly FastDAO<Reac> _reacDao =
+            new FastDAO<Reac>(Config.GetConfig("PDP.Data"), "PDB");
+
+        private static readonly FastDAO<ChildResourceInfo> _restricDao =
+            new FastDAO<ChildResourceInfo>(Config.GetConfig("PDP.Data"), "PDB");
+
+        private string _id = "NL000001";
+      
+        [SetUp] 
+        public void SetUp()
+        {
+            _reacDao.Truncate();
+            _restricDao.Truncate();
+
+            var reac = new Reac
+                {
+                    NlihcId = _id,
+                    Score = "23a*",
+                    ScoreDate = DateTime.Today,
+                    ScoreLetter = "a",
+                    ScoreNum = 23
+                };
+            _reacDao.Insert(reac);
+        }
+
+        [Test] 
+        public void TestPublicVisibility()
+        {
+            CreateRestriction(SecurityRole.@public);
+            var results = GetWithRoles();
+
+            Assert.NotNull(results.pub, "Publicly available data set should be visible to public");
+            Assert.NotNull(results.lim, "Publicly available data set should be visible to limited");
+            Assert.NotNull(results.net, "Publicly available data set should be visible to network");
+        }
+
+        [Test] 
+        public void TestLimitedVisibility()
+        {
+            CreateRestriction(SecurityRole.limited);
+            var results = GetWithRoles();
+            
+            Assert.IsNull(results.pub, "Limited available data set should be not be visible to public");
+            Assert.NotNull(results.lim, "Limited available data set should be visible to limited");
+            Assert.NotNull(results.net, "Limited available data set should be visible to network");
+        }
+
+        [Test] 
+        public void TestNetworkVisibility()
+        {
+            CreateRestriction(SecurityRole.network);
+            var results = GetWithRoles();
+            
+            Assert.IsNull(results.pub, "Network available data set should not be visible to public");
+            Assert.IsNull(results.lim, "Network available data set should not be visible to limited");
+            Assert.NotNull(results.net, "Network available data set should be visible to network");
+        }
+
+        private TestRowHolderByRole GetWithRoles()
+        {
+            ChildDisplayHelper.ReloadRoles();
+
+            return new TestRowHolderByRole
+                {
+                    pub = ChildDisplayHelper.GetRows<Reac>(_id, new[] {SecurityRole.@public}),
+                    net = ChildDisplayHelper.GetRows<Reac>(_id, new[] {SecurityRole.network}),
+                    lim = ChildDisplayHelper.GetRows<Reac>(_id, new[] {SecurityRole.limited})
+                };
+        }
+
+        private static void CreateRestriction(SecurityRole role)
+        {
+            var vis = new ChildResourceInfo
+                {
+                    Resource = ChildResourceType.ReacHistory,
+                    RoleForDisplay = role 
+                };
+            _restricDao.Insert(vis);
+        }
+    }
+}

--- a/csharp/Urban.DCP.Data/Tests/CommentTests.cs
+++ b/csharp/Urban.DCP.Data/Tests/CommentTests.cs
@@ -44,7 +44,7 @@ namespace Urban.DCP.Data.Tests
                     EmailConfirmed = true,
                     Name = "Orggy Org",
                     UserName = "ogre",
-                    Roles = "Network,public",
+                    Roles = "network,public",
                     Organization = 1
                 };
             org2 = new User()
@@ -53,7 +53,7 @@ namespace Urban.DCP.Data.Tests
                 EmailConfirmed = true,
                 Name = "John Rambo",
                 UserName = "johnrambo",
-                Roles = "Network,public",
+                Roles = "network,public",
                 Organization = 2
             };        
             UserHelper.Save(sys);

--- a/csharp/Urban.DCP.Data/Tests/PdbMapping.xml
+++ b/csharp/Urban.DCP.Data/Tests/PdbMapping.xml
@@ -67,4 +67,50 @@
     <property name="Text" column="Text"/>
   </class>
 
+  <class name="Urban.DCP.Data.Uploadable.Reac,Urban.DCP.Data" table="Reac">
+    <property name="NlihcId" column="NLIHC_ID" />
+    <property name="ScoreDate" column="ScoreDate" />
+    <property name="Score" column="Score" />
+    <property name="ScoreNum" column="ScoreNum" />
+    <property name="ScoreLetter" column="ScoreLetter" />
+  </class>
+
+  <class name="Urban.DCP.Data.Uploadable.Parcel,Urban.DCP.Data" table="Parcel">
+    <property name="NlihcId" column="NLIHC_ID" />
+    <property name="Ssl" column="SSL" />
+    <property name="ParcelType" column="ParcelType" />
+    <property name="OwnerName" column="OwnerName" />
+    <property name="OwnerDate" column="OwnerDate" />
+    <property name="OwnerType" column="OwnerType" />
+    <property name="Units" column="Units" />
+    <property name="X" column="X" />
+    <property name="Y" column="Y" />
+  </class>
+
+  <class name="Urban.DCP.Data.Uploadable.RealPropertyEvent,Urban.DCP.Data" table="RealProperty">
+    <property name="NlihcId" column="NLIHC_ID" />
+    <property name="Ssl" column="SSL" />
+    <property name="EventDate" column="EventDate" />
+    <property name="EventType" column="EventType" />
+    <property name="EventDescription" column="EventDescription" />
+  </class>
+
+  <class name="Urban.DCP.Data.Uploadable.Subsidy,Urban.DCP.Data" table="Subsidy">
+    <property name="NlihcId" column="NLIHC_ID" />
+    <property name="SubsidyActive" column="SubsidyActive" />
+    <property name="ProgramName" column="ProgramName" />
+    <property name="SubsidyInfo" column="Subsidy" />
+    <property name="ContractNumber" column="ContractNumber" />
+    <property name="UnitsAssist" column="UnitsAssist" />
+    <property name="ProgramActiveStart" column="ProgramActiveStart" />
+    <property name="ProgramActiveEnd" column="ProgramActiveEnd" />
+    <property name="SubsidyInfoSource" column="SubsidyInfoSource" />
+    <property name="SubsidyNotes" column="SubsidyNotes" />
+    <property name="SubsidyUpdate" column="SubsidyUpdate" />
+  </class>
+
+  <class name="Urban.DCP.Data.Uploadable.Display.ChildResourceInfo,Urban.DCP.Data" table="ChildResourceRestrictions">
+    <property name="Resource" column="ChildResource" type="string" />
+    <property name="RoleForDisplay" column="RoleForDisplay" type="string"/>
+  </class>
 </hibernate-mapping>

--- a/csharp/Urban.DCP.Data/Uploadable/Display/ChildDisplayHelper.cs
+++ b/csharp/Urban.DCP.Data/Uploadable/Display/ChildDisplayHelper.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Azavea.Database;
+using Azavea.Open.Common;
+using Azavea.Open.DAO.Criteria;
+
+namespace Urban.DCP.Data.Uploadable.Display
+{
+    public class ChildDisplayHelper
+    {
+
+        internal static readonly FastDAO<ChildResourceInfo> Dao =
+            new FastDAO<ChildResourceInfo>(Config.GetConfig("PDP.Data"), "PDB");
+
+        private static readonly IDictionary<Type, ChildResourceType> ResourceMap = 
+            new Dictionary<Type, ChildResourceType>
+            {
+                {typeof (Reac), ChildResourceType.ReacHistory},
+                {typeof (Parcel), ChildResourceType.ParcelHistory},
+                {typeof (RealPropertyEvent), ChildResourceType.RealPropertyHistory},
+                {typeof (Subsidy), ChildResourceType.Subsidy}
+            };
+
+        private static IDictionary<ChildResourceType, SecurityRole> _roles;
+
+        public static bool DisplayForRole(ChildResourceType type, IList<SecurityRole> roles)
+        {
+            if (_roles == null)
+            {
+                ReloadRoles();
+            }
+
+            if (_roles.ContainsKey(type))
+            {
+                var highest = roles.OrderBy(r => (int) r).Last();
+                return highest >= _roles[type];
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Refresh the cached role per resource settings
+        /// </summary>
+        public static void ReloadRoles()
+        {
+            var childen = Dao.Get();
+            _roles = new Dictionary<ChildResourceType, SecurityRole>();
+            foreach (var child in childen)
+            {
+                _roles.Add(child.Resource, child.RoleForDisplay);
+            }
+
+        }
+
+        public static IList<T> GetRows<T>(string nlihcId, IList<SecurityRole> roles ) 
+            where T: class , IDisplaySortable, new()
+        {
+            var dao = new FastDAO<T>(Config.GetConfig("PDP.Data"), "PDB");
+            var crit = new DaoCriteria(new EqualExpression("NlihcId", nlihcId));
+            var sortField = Activator.CreateInstance<T>().GetSortField();
+            crit.Orders.Add(new SortOrder(sortField, SortType.Desc));
+            return DisplayForRole(ResourceMap[typeof (T)], roles) ? dao.Get(crit) : null;
+        }
+    }
+}

--- a/csharp/Urban.DCP.Data/Uploadable/Display/ChildResourceInfo.cs
+++ b/csharp/Urban.DCP.Data/Uploadable/Display/ChildResourceInfo.cs
@@ -1,0 +1,14 @@
+﻿namespace Urban.DCP.Data.Uploadable.Display
+{
+    public class ChildResourceInfo
+    {
+        /// <summary>
+        /// Type of resource to display
+        /// </summary>
+        public ChildResourceType Resource;
+        /// <summary>
+        /// Minimum required role for displaying the resource
+        /// </summary>
+        public SecurityRole RoleForDisplay;
+    }
+}

--- a/csharp/Urban.DCP.Data/Uploadable/Display/ChildResourceType.cs
+++ b/csharp/Urban.DCP.Data/Uploadable/Display/ChildResourceType.cs
@@ -1,0 +1,10 @@
+﻿namespace Urban.DCP.Data.Uploadable.Display
+{
+    public enum ChildResourceType
+    {
+        ReacHistory,
+        ParcelHistory,
+        RealPropertyHistory,
+        Subsidy
+    }
+}

--- a/csharp/Urban.DCP.Data/Uploadable/Display/IDisplaySortable.cs
+++ b/csharp/Urban.DCP.Data/Uploadable/Display/IDisplaySortable.cs
@@ -1,0 +1,11 @@
+﻿namespace Urban.DCP.Data.Uploadable.Display
+{
+    /// <summary>
+    /// DAO types must specify the sort field for generic
+    /// sort during query
+    /// </summary>
+    public interface IDisplaySortable
+    {
+        string GetSortField();
+    }
+}

--- a/csharp/Urban.DCP.Data/Uploadable/Parcel.cs
+++ b/csharp/Urban.DCP.Data/Uploadable/Parcel.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using FileHelpers;
+using Urban.DCP.Data.Uploadable.Display;
 
 namespace Urban.DCP.Data.Uploadable
 {
     [DelimitedRecord(",")] 
     [IgnoreFirst(1)]
-    public class Parcel
+    public class Parcel: IDisplaySortable
     {
 
         public string NlihcId;
@@ -38,6 +39,10 @@ namespace Urban.DCP.Data.Uploadable
         public int? Units;
         public double? X;
         public double? Y;
+        public string GetSortField()
+        {
+            return "OwnerDate";
+        }
     }
 
     public class ParcelUploader: AbstractUploadable<Parcel>, ILoadable

--- a/csharp/Urban.DCP.Data/Uploadable/Reac.cs
+++ b/csharp/Urban.DCP.Data/Uploadable/Reac.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using FileHelpers;
+using Urban.DCP.Data.Uploadable.Display;
 
 namespace Urban.DCP.Data.Uploadable
 {
     [DelimitedRecord(",")] 
     [IgnoreFirst(1)]
-    public class Reac
+    public class Reac: IDisplaySortable 
     {
 
         public string NlihcId;
@@ -26,6 +27,11 @@ namespace Urban.DCP.Data.Uploadable
         /// Letter component of score
         /// </summary>
         public string ScoreLetter;
+
+        public string GetSortField()
+        {
+            return "ScoreDate";
+        }
     }
 
     public class ReacUploader: AbstractUploadable<Reac>, ILoadable

--- a/csharp/Urban.DCP.Data/Uploadable/RealPropertyEvent.cs
+++ b/csharp/Urban.DCP.Data/Uploadable/RealPropertyEvent.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using FileHelpers;
+using Urban.DCP.Data.Uploadable.Display;
 
 namespace Urban.DCP.Data.Uploadable
 {
     [DelimitedRecord(",")] 
     [IgnoreFirst(1)]
-    public class RealPropertyEvent
+    public class RealPropertyEvent: IDisplaySortable
     {
 
         public string NlihcId;
@@ -28,6 +29,11 @@ namespace Urban.DCP.Data.Uploadable
         /// </summary>
         [FieldQuoted('"', QuoteMode.OptionalForRead)]
         public string EventDescription;
+
+        public string GetSortField()
+        {
+            return "EventDate";
+        }
     }
 
     public class PropertyEventUploader: AbstractUploadable<RealPropertyEvent>, ILoadable

--- a/csharp/Urban.DCP.Data/Uploadable/Subsidy.cs
+++ b/csharp/Urban.DCP.Data/Uploadable/Subsidy.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using FileHelpers;
+using Urban.DCP.Data.Uploadable.Display;
 
 namespace Urban.DCP.Data.Uploadable
 {
     [DelimitedRecord(",")] 
     [IgnoreFirst(1)]
-    public class Subsidy
+    public class Subsidy: IDisplaySortable 
     {
         public string NlihcId;
         /// <summary>
@@ -51,6 +52,11 @@ namespace Urban.DCP.Data.Uploadable
         /// </summary>
         [FieldConverter(ConverterKind.Date, "MM/dd/yyyy")] 
         public DateTime? SubsidyUpdate;
+
+        public string GetSortField()
+        {
+            return "ProgramActiveStart";
+        }
     }
 
     public class SubsidyUploader: AbstractUploadable<Subsidy>, ILoadable

--- a/csharp/Urban.DCP.Data/Urban.DCP.Data.csproj
+++ b/csharp/Urban.DCP.Data/Urban.DCP.Data.csproj
@@ -147,9 +147,14 @@
     <Compile Include="PDB\PdbSubCategory.cs" />
     <Compile Include="AbstractTableColumnMetadata.cs" />
     <Compile Include="PropertyCommentInfo.cs" />
+    <Compile Include="Tests\ChildDisplayTests.cs" />
     <Compile Include="Tests\CommentTests.cs" />
     <Compile Include="UiComment.cs" />
     <Compile Include="Uploadable\AbstractUploadable.cs" />
+    <Compile Include="Uploadable\Display\ChildDisplayHelper.cs" />
+    <Compile Include="Uploadable\Display\ChildResourceInfo.cs" />
+    <Compile Include="Uploadable\Display\ChildResourceType.cs" />
+    <Compile Include="Uploadable\Display\IDisplaySortable.cs" />
     <Compile Include="Uploadable\RealPropertyEvent.cs" />
     <Compile Include="Uploadable\LoadHelper.cs" />
     <Compile Include="Uploadable\Parcel.cs" />

--- a/csharp/Urban.DCP.Data/User.cs
+++ b/csharp/Urban.DCP.Data/User.cs
@@ -90,7 +90,7 @@ namespace Urban.DCP.Data
         /// </summary>
         public bool IsNetworked()
         {
-            return RolesList.Contains(SecurityRole.Network);
+            return RolesList.Contains(SecurityRole.network);
         }
 
         /// <summary>
@@ -163,7 +163,7 @@ namespace Urban.DCP.Data
         {
             if (organization == null || organization == Urban.DCP.Data.Organization.NO_ORG) {
                 {
-                    RemoveRole(SecurityRole.Network);
+                    RemoveRole(SecurityRole.network);
                 }
                 Organization = null;
             }
@@ -173,7 +173,7 @@ namespace Urban.DCP.Data
             }
             else
             {
-                AddRole(SecurityRole.Network);
+                AddRole(SecurityRole.network);
                 Organization = organization;
             }
         }

--- a/csharp/Urban.DCP.Handlers/PropertyChildrenHandler.cs
+++ b/csharp/Urban.DCP.Handlers/PropertyChildrenHandler.cs
@@ -1,0 +1,31 @@
+﻿using Azavea.Web;
+using Azavea.Web.Handler;
+using Urban.DCP.Data;
+using Urban.DCP.Data.Uploadable;
+using Urban.DCP.Data.Uploadable.Display;
+
+namespace Urban.DCP.Handlers
+{
+    public class PropertyChildrenHandler : BaseHandler
+    {
+        /// <summary>
+        /// Enable response compression.
+        /// </summary>
+        public PropertyChildrenHandler(): base(true) {}
+
+        protected override void InternalGET(System.Web.HttpContext context, HandlerTimedCache cache)
+        {
+            var roles = UserHelper.GetUserRoles(context.User.Identity.Name);
+            var id = WebUtil.GetParam(context, "id", false);
+
+            context.Response.Write(WebUtil.ObjectToJson(new
+                {
+                    Reac = ChildDisplayHelper.GetRows<Reac>(id, roles),
+                    Parcel = ChildDisplayHelper.GetRows<Parcel>(id, roles),
+                    RealProperty = ChildDisplayHelper.GetRows<RealPropertyEvent>(id, roles),
+                    Subsidy = ChildDisplayHelper.GetRows<Subsidy>(id, roles)
+                }
+            ));
+        }
+    }
+}

--- a/csharp/Urban.DCP.Handlers/PropertyDetailsHandler.cs
+++ b/csharp/Urban.DCP.Handlers/PropertyDetailsHandler.cs
@@ -12,30 +12,27 @@ namespace Urban.DCP.Handlers
         /// <summary>
         /// Enable response compression.
         /// </summary>
-        public PropertyDetailsHandler()
-            : base(true)
-        {
-        }
+        public PropertyDetailsHandler(): base(true) {}
 
         protected override void InternalGET(System.Web.HttpContext context, HandlerTimedCache cache)
         {
-            IList<SecurityRole> roles = UserHelper.GetUserRoles(context.User.Identity.Name);
+            var roles = UserHelper.GetUserRoles(context.User.Identity.Name);
             
-            PdbTwoTableHelper dataHelper = new PdbTwoTableHelper(Config.GetConfig("PDP.Data"), "Properties",
+            var dataHelper = new PdbTwoTableHelper(Config.GetConfig("PDP.Data"), "Properties",
                 new [] {PdbEntityType.Properties, PdbEntityType.Reac, PdbEntityType.RealProperty});
 
-            List<string> ids = new List<string>();
-            string id = WebUtil.GetParam(context, "id", true);
+            var ids = new List<string>();
+            var id = WebUtil.GetParam(context, "id", true);
             if (id != null)
             {
                 ids.Add(id);
             }
             else
             {
-                string idList = WebUtil.GetParam(context, "ids", false);
+                var idList = WebUtil.GetParam(context, "ids", false);
                 ids.AddRange(idList.Split(','));
             }
-            PdbResultsWithMetadata list = dataHelper.Query(ids, roles);
+            var list = dataHelper.Query(ids, roles);
 
             context.Response.Write(WebUtil.ObjectToJson(list));
         }

--- a/csharp/Urban.DCP.Handlers/Urban.DCP.Handlers.csproj
+++ b/csharp/Urban.DCP.Handlers/Urban.DCP.Handlers.csproj
@@ -135,6 +135,7 @@
     <Compile Include="AppHealth.cs" />
     <Compile Include="CommentHandler.cs" />
     <Compile Include="CommentImageHandler.cs" />
+    <Compile Include="PropertyChildrenHandler.cs" />
     <Compile Include="ExportHandler.cs" />
     <Compile Include="UploadRevisionHandler.cs" />
     <Compile Include="LoggerHandler.cs" />

--- a/csharp/Urban.DCP.Web/Urban.DCP.Web.csproj
+++ b/csharp/Urban.DCP.Web/Urban.DCP.Web.csproj
@@ -116,6 +116,7 @@
     <Content Include="clientsrc\pdp\css\pdp-manage-orgs.css" />
     <Content Include="clientsrc\pdp\pdp-comment-controller.js" />
     <Content Include="clientsrc\pdp\pdp-manage-orgs.js" />
+    <Content Include="clientsrc\pdp\pdp-project-details.js" />
     <Content Include="clientsrc\pdp\pdp-upload-revision-controller.js" />
     <Content Include="clientsrc\pdp\pdp-widget-pdb-control-range.js" />
     <Content Include="clientsrc\underscore.js" />
@@ -294,6 +295,7 @@
     <Content Include="handlers\logger.ashx" />
     <Content Include="handlers\upload-revisions.ashx" />
     <Content Include="admin\export.ashx" />
+    <Content Include="handlers\property-details-children.ashx" />
     <None Include="minifier.conf" />
     <Content Include="packages.config" />
   </ItemGroup>

--- a/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-project-details.js
+++ b/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-project-details.js
@@ -1,0 +1,56 @@
+﻿(function(N) {
+    N.ProjectDetailsController = function(id) {
+        this._id = id;
+    };
+
+    N.ProjectDetailsController.prototype._load = function () {
+        return $.ajax('handlers/property-details-children.ashx', {
+            dataType: 'json',
+            data: { id: this._id }
+        });
+    };
+
+    N.ProjectDetailsController.prototype.render = function($target) {
+        var self = this,
+            xhr = this._load();
+        xhr.done(function(details) {
+            self.renderDetails(details, $target);
+        });
+    };
+
+    N.ProjectDetailsController.prototype.renderDetails = function(details, $target) {
+        var panelTmpl = _.template($('#project-details-template').html()),
+            reacTmpl = _.template($('#reac-display-template').html()),
+            parcelTmpl = _.template($('#parcel-display-template').html()),
+            eventTmpl = _.template($('#property-display-template').html()),
+            subsidyTmpl = _.template($('#subsidy-display-template').html()),
+            formatDate = function (datestring) {
+                if (!datestring) return '';
+                return moment(datestring).format("MM/DD/YYYY");
+            },
+            renderAndFormat = function(list, dateFields, tmpl) {
+                if (list) {
+                    return _.map(list, function (x) {
+                        var override = {};
+                        _.each(dateFields, function(name) {
+                            override[name] = formatDate(x[name]);
+                        });
+                        var ctx = $.extend(x, override);
+                        return tmpl(ctx);
+                    }).join('');
+                }
+                return null;
+            };
+
+        var children = {
+            reac: renderAndFormat(details.Reac, ['ScoreDate'], reacTmpl),
+            parcel: renderAndFormat(details.Parcel, ['OwnerDate'], parcelTmpl),
+            property: renderAndFormat(details.Property, ['EventDate'], eventTmpl),
+            subsidy: renderAndFormat(details.Subsidy,
+                ['ProgramActiveStart', 'ProgramActiveEnd', 'SubsidyUpdate'], subsidyTmpl)
+        };
+
+        $target.empty().append(panelTmpl(children));
+    };
+
+}(PDP));

--- a/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-widget-pdb-longview.js
+++ b/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-widget-pdb-longview.js
@@ -122,7 +122,9 @@
             } else {
                _displayNoData();
             }
-          
+
+            var childDetails = new P.ProjectDetailsController(propId);
+            childDetails.render($('#pdp-child-display'));
 
             new P.CommentController({
                 propId: propId,
@@ -219,7 +221,7 @@
         // Create the dialog that will show longview details, including space for streetview and title
         var _createLongviewDialog = Azavea.tryCatch('create dialog container', function(){            
             // Create div container for caption, the list, and GSV
-            _$container = $('<div class="pdp-longview"><div class="pdp-longview-caption"></div><table id="pdp-longview-table" class="pdp-longview-list"></table><div id="pdp-streetview-title">Approximate View</div><div class="pdp-longview-street"></div><div id="pdp-longview-comments"></div><div class="pdp-longview-comment-form"></div></div>');
+            _$container = $('<div class="pdp-longview"><div class="pdp-longview-caption"></div><table id="pdp-longview-table" class="pdp-longview-list"></table><div id="pdp-streetview-title">Approximate View</div><div class="pdp-longview-street"></div><div id="pdp-child-display"></div><div id="pdp-longview-comments"></div><div class="pdp-longview-comment-form"></div></div>');
             _$street = $('.pdp-longview-street', _$container);
            
             // Create a link to report download link

--- a/csharp/Urban.DCP.Web/default.aspx
+++ b/csharp/Urban.DCP.Web/default.aspx
@@ -66,6 +66,81 @@
         <textarea id="new-comment"></textarea><br />
         <button id="submit-new-comment">Submit Comment</button>
     </script>
+   
+    <script type="text/template" id="project-details-template">
+        <div id="project-child-details">
+            {% if (reac) { %}
+            <h4>REAC Scores</h4>
+            <table>
+                <thead>
+                    <th>Score Date</th><th>Score</th>
+                </thead>
+                <tbody>
+                    {{reac}}
+                </tbody>
+            </table>
+            {% } %}
+            
+            {% if (parcel) { %}
+            <h4>Parcel Records</h4>
+            <table>
+                <thead>
+                    <th>SSL</th><th>Parcel Type</th><th>Owner Name</th><th>Owner Date</th><th>Owner Type</th><th>Units</th>
+                </thead>
+                <tbody>
+                    {{parcel}}
+                </tbody>
+            </table>
+            {% } %}
+
+            {% if (property) { %}
+            <h4>Real Property Events</h4>
+            <table>
+                <thead>
+                    <th>SSL</th><th>Event Date</th><th>Event Type</th><th>Event Description</th>
+                </thead>
+                <tbody>
+                    {{property}}
+                </tbody>
+            </table>
+            {% } %}
+
+            {% if (subsidy) { %}
+            <h4>Subsidy Details</h4>
+            <table>
+                <thead>
+                    <th>Active</th><th>Program</th><th>Contract #</th><th>Units Assist</th><th>Start</th><th>End</th><th>Source</th><th>Updated</th>
+                </thead>
+                <tbody>
+                    {{subsidy}}
+                </tbody>
+            </table>
+            {% } %}
+        </div>
+    </script> 
+    <script type="text/template" id="reac-display-template">
+        <tr>
+            <td>{{ScoreDate}}</td><td>{{Score}}</td>
+        </tr>    
+    </script>
+
+    <script type="text/template" id="parcel-display-template">
+        <tr>
+            <td>{{Ssl}}</td><td>{{ParcelType}}</td><td>{{OwnerName}}</td><td>{{OwnerDate}}</td><td>{{OwnerType}}</td><td>{{Units}}</td>
+        </tr>    
+    </script>
+
+    <script type="text/template" id="property-display-template">
+        <tr>
+            <td>{{Ssl}}</td><td>{{EventDate}}</td><td>{{EventType}}</td><td>{{EventDescription}}</td>
+        </tr>    
+    </script>
+
+    <script type="text/template" id="subsidy-display-template">
+        <tr>
+            <td>{{SubsidyActive}}</td><td>{{ProgramName}}</td><td>{{ContractNumber}}</td><td>{{UnitsAssist}}</td><td>{{ProgramActiveStart}}</td><td>{{ProgramActiveEnd}}</td><td>{{SubsidyInfoSource}}</td><td>{{SubsidyNotes}}</td><td>{{SubsidyUpdate}}</td>
+        </tr>    
+    </script>
 
     <script type="text/template" id="comment-template">
         <div style=""clear:both"></div>

--- a/csharp/Urban.DCP.Web/handlers/property-details-children.ashx
+++ b/csharp/Urban.DCP.Web/handlers/property-details-children.ashx
@@ -1,0 +1,1 @@
+﻿<%@ WebHandler Language="C#" Class="Urban.DCP.Handlers.PropertyChildrenHandler" %>

--- a/csharp/Urban.DCP.Web/minifier.conf
+++ b/csharp/Urban.DCP.Web/minifier.conf
@@ -25,6 +25,7 @@ clientsrc\pdp\pdp-widget-pdb-controls.js
 clientsrc\pdp\pdp-widget-pdb-control-range.js
 clientsrc\pdp\pdp-widget-export.js
 clientsrc\pdp\pdp-comment-controller.js
+clientsrc\pdp\pdp-project-details.js
 clientsrc\pdp\pdp-widget-pdb-longview.js
 clientsrc\pdp\pdp-map.js
 clientsrc\pdp\pdp-widget-map-layers.js


### PR DESCRIPTION
Allow the long view display form to query and display for all related
child records for the given property.  Administrators can adjust which
data sets are available to users of specific roles.
