### PR TITLE
Allow for export only `uploadables`, for comments

### DIFF
--- a/csharp/Urban.DCP.Data/Comment.cs
+++ b/csharp/Urban.DCP.Data/Comment.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using Azavea.Database;
 using Azavea.Open.Common;
 using Azavea.Open.DAO.Criteria;
+using FileHelpers;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Urban.DCP.Data.Uploadable;
 
 namespace Urban.DCP.Data
 {
@@ -19,6 +21,8 @@ namespace Urban.DCP.Data
         public UnauthorizedToEditCommentException(string msg) : base(msg) { }
     }
 
+    [IgnoreFirst(1)]
+    [DelimitedRecord(",")]
     public class Comment
     {
         private static readonly FastDAO<Comment> _dao =
@@ -52,8 +56,9 @@ namespace Urban.DCP.Data
                 return null; 
             }
         }
-
+        [FieldConverter(ConverterKind.Date, "MM/dd/yyyy")]
         public DateTime Created;
+        [FieldConverter(ConverterKind.Date, "MM/dd/yyyy")]
         public DateTime Modified;
         public string Username;
 
@@ -64,15 +69,17 @@ namespace Urban.DCP.Data
         public string LastEditorId;
 
         /// <summary>
+        /// Text value of comment
+        /// </summary>
+        [FieldQuoted]
+        public string Text;
+
+        /// <summary>
         /// Optional Image attached to comment
         /// </summary>
         [JsonIgnore]
+        [FieldNotInFile]
         public byte[] Image;
-
-        /// <summary>
-        /// Text value of comment
-        /// </summary>
-        public string Text;
 
         [JsonIgnore]
         public User User
@@ -267,4 +274,17 @@ namespace Urban.DCP.Data
         }
     }
 
+    public class CommentExporter : AbstractLoadable<Comment>, ILoadable
+    {
+        public CommentExporter()
+        {
+            ReadOnly = true;
+        }
+
+        public override UploadTypes UploadType
+        {
+            get { return UploadTypes.Comment; }
+        }
+
+    }
 }

--- a/csharp/Urban.DCP.Data/PDB/PdbAttribute.cs
+++ b/csharp/Urban.DCP.Data/PDB/PdbAttribute.cs
@@ -214,7 +214,7 @@ namespace Urban.DCP.Data.PDB
         }
     }
 
-    public class AttributeUploader: AbstractUploadable<PdbAttribute>, ILoadable
+    public class AttributeUploader: AbstractLoadable<PdbAttribute>, ILoadable
     {
         public override UploadTypes UploadType
         {

--- a/csharp/Urban.DCP.Data/Tests/PdbMapping.xml
+++ b/csharp/Urban.DCP.Data/Tests/PdbMapping.xml
@@ -57,14 +57,14 @@
       <generator class="native" />
     </id>
     <property name="NlihcId" column="NLIHCID" />
-    <property name="Username" column="Username"/>
     <property name="AccessLevel" column="AccessLevel" type="string" />
     <property name="AssociatedOrgId" column="Org" />
     <property name="Created" column="Created"/>
     <property name="Modified" column="Modified" />
+    <property name="Username" column="Username"/>
     <property name="LastEditorId" column="LastEditorId"/>
-    <property name="Image" column="Image" type="bytearray" />
     <property name="Text" column="Text"/>
+    <property name="Image" column="Image" type="bytearray" />
   </class>
 
   <class name="Urban.DCP.Data.Uploadable.Reac,Urban.DCP.Data" table="Reac">

--- a/csharp/Urban.DCP.Data/Uploadable/AbstractUploadable.cs
+++ b/csharp/Urban.DCP.Data/Uploadable/AbstractUploadable.cs
@@ -16,11 +16,19 @@ namespace Urban.DCP.Data.Uploadable
         String Export();
     }
 
-    public abstract class AbstractUploadable<T> where T: class, new()
+    public abstract class AbstractLoadable<T> where T: class, new()
     {
         internal static readonly FastDAO<T> _dao =
             new FastDAO<T>(Config.GetConfig("PDP.Data"), "PDB");
 
+        /// <summary>
+        /// Is this dataset only available for export?
+        /// </summary>
+        public bool ReadOnly = false;
+
+        /// <summary>
+        /// The upload type of this dataset
+        /// </summary>
         public abstract UploadTypes UploadType { get; }
 
         /// <summary>
@@ -64,6 +72,8 @@ namespace Urban.DCP.Data.Uploadable
         /// <returns></returns>
         public ImportResult Load(Stream data, User user)
         {
+            if (ReadOnly) return null;
+
             var reader = new StreamReader(data);
             var csv = reader.ReadToEnd();
            

--- a/csharp/Urban.DCP.Data/Uploadable/LoadHelper.cs
+++ b/csharp/Urban.DCP.Data/Uploadable/LoadHelper.cs
@@ -29,6 +29,9 @@ namespace Urban.DCP.Data.Uploadable
                 case UploadTypes.Subsidy:
                     loader = new SubsidyUploader();
                     break;
+                case UploadTypes.Comment:
+                    loader = new CommentExporter();
+                    break;
                 default:
                     throw new ApplicationException(String.Format("{0} is not a valid upload type.", type));
             }

--- a/csharp/Urban.DCP.Data/Uploadable/Parcel.cs
+++ b/csharp/Urban.DCP.Data/Uploadable/Parcel.cs
@@ -45,7 +45,7 @@ namespace Urban.DCP.Data.Uploadable
         }
     }
 
-    public class ParcelUploader: AbstractUploadable<Parcel>, ILoadable
+    public class ParcelUploader: AbstractLoadable<Parcel>, ILoadable
     {
         public override UploadTypes UploadType
         {

--- a/csharp/Urban.DCP.Data/Uploadable/Project.cs
+++ b/csharp/Urban.DCP.Data/Uploadable/Project.cs
@@ -79,7 +79,7 @@ namespace Urban.DCP.Data.Uploadable
 
     }
 
-    public class ProjectUploader: AbstractUploadable<Project>, ILoadable
+    public class ProjectUploader: AbstractLoadable<Project>, ILoadable
     {
         public override UploadTypes UploadType
         {

--- a/csharp/Urban.DCP.Data/Uploadable/Reac.cs
+++ b/csharp/Urban.DCP.Data/Uploadable/Reac.cs
@@ -34,7 +34,7 @@ namespace Urban.DCP.Data.Uploadable
         }
     }
 
-    public class ReacUploader: AbstractUploadable<Reac>, ILoadable
+    public class ReacUploader: AbstractLoadable<Reac>, ILoadable
     {
         public override UploadTypes UploadType
         {

--- a/csharp/Urban.DCP.Data/Uploadable/RealPropertyEvent.cs
+++ b/csharp/Urban.DCP.Data/Uploadable/RealPropertyEvent.cs
@@ -36,7 +36,7 @@ namespace Urban.DCP.Data.Uploadable
         }
     }
 
-    public class PropertyEventUploader: AbstractUploadable<RealPropertyEvent>, ILoadable
+    public class PropertyEventUploader: AbstractLoadable<RealPropertyEvent>, ILoadable
     {
         public override UploadTypes UploadType
         {

--- a/csharp/Urban.DCP.Data/Uploadable/Subsidy.cs
+++ b/csharp/Urban.DCP.Data/Uploadable/Subsidy.cs
@@ -65,7 +65,7 @@ namespace Urban.DCP.Data.Uploadable
         }
     }
 
-    public class SubsidyUploader: AbstractUploadable<Subsidy>, ILoadable
+    public class SubsidyUploader: AbstractLoadable<Subsidy>, ILoadable
     {
         public override UploadTypes UploadType
         {

--- a/csharp/Urban.DCP.Data/Uploadable/UploadTypes.cs
+++ b/csharp/Urban.DCP.Data/Uploadable/UploadTypes.cs
@@ -1,7 +1,8 @@
 ﻿namespace Urban.DCP.Data.Uploadable
 {
     /// <summary>
-    /// The various types of data that can be uploaded by the client
+    /// The various types of data that can be loaded (import/export or both)
+    /// by the client
     /// </summary>
     public enum UploadTypes
     {
@@ -10,6 +11,7 @@
         Reac,
         Parcel, 
         RealPropertyEvent,
-        Subsidy
+        Subsidy,
+        Comment
     }
 }

--- a/csharp/Urban.DCP.Web/admin/data.aspx
+++ b/csharp/Urban.DCP.Web/admin/data.aspx
@@ -14,8 +14,9 @@
                  <option value="RealPropertyEvent">Real Property Events</option>
                  <option value="Subsidy">Subsidy Details</option>
                  <option value="Attribute">Filter & Display Attributes</option>
+                 <option value="Comment" data-readonly="true">Property Comments</option>
              </select>
-             <input type="submit" value="Upload"/>
+             <input id="upload-set" type="submit" value="Upload"/>
          </form>
          <form id="export" method="GET" action="export.ashx" target="_blank">
              <input id="export-type" name="type" type="hidden"/>
@@ -46,10 +47,13 @@
         _.templateSettings = {
             interpolate: /\{\{(.+?)\}\}/g
         };
-
+        var $upload = $('#upload-set');
         // Use the same type selector for both export and import
         $('#type').change(function() {
-            $('#export-type').val($(this).val());
+            var $this = $(this);
+            $('#export-type').val($this.val());
+            var isReadOnly = $this.find('option:selected').data('readonly') || false;
+            $upload.attr('disabled', isReadOnly);
         }).change();
 
         // Set the right ref path for this /admin resouce


### PR DESCRIPTION
Comments can be exported, but not imported.  Make the Uploadable class
a little more generic to accept this concept.

Fixes #58
