### PR TITLE
Signup process includes company/org

### DIFF
--- a/csharp/Urban.DCP.Data/User.cs
+++ b/csharp/Urban.DCP.Data/User.cs
@@ -38,6 +38,11 @@ namespace Urban.DCP.Data
         /// </summary>
         public string Name;
         /// <summary>
+        /// Company or organization affiliation, as contact information, not
+        /// Preservation Network Organization
+        /// </summary>
+        public string Affiliation;
+        /// <summary>
         /// The actual text in the column - a comma separated list of roles
         /// </summary>
         public string Roles;
@@ -50,9 +55,15 @@ namespace Urban.DCP.Data
         /// </summary>
         public Boolean EmailConfirmed;
         /// <summary>
-        /// The organization id.
+        /// The Preservation Network Organization id that this user
+        /// is affiliated with
         /// </summary>
         public int? Organization;
+        /// <summary>
+        /// During signup, did the user request to be considered for a
+        /// Preservation Network affiliation?
+        /// </summary>
+        public bool NetworkRequested;
 
 
         /// <summary>

--- a/csharp/Urban.DCP.Data/UserHelper.cs
+++ b/csharp/Urban.DCP.Data/UserHelper.cs
@@ -112,8 +112,11 @@ namespace Urban.DCP.Data
         /// <param name="email">The email address of this user.</param>
         /// <param name="name">The actual name of this user.</param>
         /// <param name="roles">A comma seperated list of roles assigned to this user.</param>
+        /// <param name="affiliation">The company or organization the user is affiliated with.
+        /// Not necessarily the Network Preservation org, but could also be.</param>
+        /// <param name="network">Did this user request to be recognized as a Network member?</param>
         public static User CreateUser(string userName, string hashedPassword, string email,
-                                            string name, string roles)
+              string name, string roles, string affiliation = null, bool network = false)
         {
             User user = new User();
 
@@ -123,6 +126,9 @@ namespace Urban.DCP.Data
             user.Email = email;
             user.Name = name;
             user.Active = true;
+            user.Affiliation = affiliation;
+            user.NetworkRequested = network;
+
             if (StringHelper.IsNonBlank(roles))
             {
                 user.Roles = roles;

--- a/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-data.js
+++ b/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-data.js
@@ -77,10 +77,10 @@
     });
 
     // Create a new user and logs them in
-    P.Data.createUser = Azavea.tryCatch('data create user', function(username, name, email, password, roles, callback, error) {
-        var url = P.Data.path + 'handlers/users.ashx';
-        var data = { username: username, name: name, email: email, password: password, roles: roles };
-        _callHandler('POST', url, data, callback, error);
+    P.Data.createUser = Azavea.tryCatch('data create user',
+        function (signupFields, callback, error) {
+            var url = P.Data.path + 'handlers/users.ashx';
+            _callHandler('POST', url, signupFields, callback, error);
     });
     
     // Get details of single user

--- a/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-widget-signup.js
+++ b/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-widget-signup.js
@@ -78,6 +78,7 @@
 		                });
             });
             */
+            var successMsg = "Thank you for registering, please check your email for verification instructions.";
             
             // Submit our signup data on the button click
             $('#pdp-signup-button').button().click(function() {
@@ -87,33 +88,21 @@
                     
                     // Try validating the user input
                     if(P.Form.validate(_options.fields, {}, '.pdp-signup-panel')) {
-                        var username = $('#pdp-signup-username').val(),
-                            password = $('#pdp-signup-password').val(),
-                            name = $('#pdp-signup-name').val(),
-                            email = $('#pdp-signup-email').val();
-                            roles = '';
+                        var signupFields = {
+                            username: $('#pdp-signup-username').val(),
+                            affiliation: $('#pdp-signup-org').val(),
+                            password: $('#pdp-signup-password').val(),
+                            name: $('#pdp-signup-name').val(),
+                            email: $('#pdp-signup-email').val(),
+                            roles: '',
+                            network: $('#pdp-signup-network').is(':checked')
+                        };
                         
-                            P.Data.createUser(username, name, email, password, roles,
-
-                                /*
-                                In the future we may come back to this if email ver isn't applicable
-                                to all classes of user.
-
-                                function () {
-                            //Redirect to the default page
-                            P.Data.login(username, password, function(user) {
-                                $(_options.bindTo).trigger('pdp-login-success', [user]);
-                                $(_options.bindTo).trigger('pdp-login-status-refresh', [user]);
-                            }, function() {
-                                window.location.href = _options.landingUrl;
-                            });
-                        }, function(respText) {
-                            _displayErrorMsg(respText);
-                        }*/
-                        function () {
-                            P.Util.alert("Please check your email for verification instructions", "Registration Successfull",
-                                function () { window.location.href = _options.landingUrl; }
-                            );
+                        P.Data.createUser(signupFields,
+                            function () {
+                                P.Util.alert(successMsg, "Registration Successfull",
+                                    function () { window.location.href = _options.landingUrl; }
+                                );
                         });
                     } else {
                         _displayErrorMsg(P.Form.validationMsg);
@@ -144,6 +133,12 @@
                                     '</div>' +
                                 '</li>' +
                                 '<li>' +
+                                    '<label for="pdp-signup-org" class="pdp-form-label">Company/Organization:</label>' +
+                                    '<div class="pdp-form-ctrl">' +
+                                        '<input id="pdp-signup-org" type="text" class="pdp-input-shorttext" tabindex="2" />' +
+                                    '</div>' +
+                                '</li>' +
+                                '<li>' +
                                     '<label for="pdp-signup-email" class="pdp-form-label">Email:</label>' +
                                     '<div class="pdp-form-ctrl">' +
                                         '<input id="pdp-signup-email" type="text" class="pdp-input-shorttext" tabindex="3" />' +
@@ -169,6 +164,12 @@
                                         '<label class="pdp-form-label">I Agree to the <a id="pdp-signup-terms-display" href="javascript:void(0);">Terms of Service</a></label>' +
                                     '</div>' +
                                 '</li>' +*/
+                                '<li>' +
+                                    '<div class="pdp-form-ctrl">' +
+                                        '<input id="pdp-signup-network" type="checkbox" class="pdp-input pdp-input-checkbox" tabindex="6" />' +
+                                        '<label class="pdp-form-label">I am a member of the <a id="pdp-signup-network" target="_blank" href="http://www.neighborhoodindicators.org/activities/partner/dc-preservation-network">Preservation Network</a></label>' +
+                                    '</div>' +
+                                '</li>' +
                             '</ul>' +
                             '<div class="pdp-form-buttons">' +
                                 '<button id="pdp-signup-button" class="pdp-button" tabindex="7">Sign Up</button>' +


### PR DESCRIPTION
When signing up, the user can specify an affiliation with a company/org
and also specify if they are requesting access to features for 
Preservation Network members.

Fixes #59 
