### PR TITLE
Fix pacel dataset uploads

### DIFF
--- a/csharp/Urban.DCP.Data/Uploadable/Parcel.cs
+++ b/csharp/Urban.DCP.Data/Uploadable/Parcel.cs
@@ -24,14 +24,16 @@ namespace Urban.DCP.Data.Uploadable
         [FieldQuoted('"', QuoteMode.OptionalForRead)]
         public string OwnerName;
         /// <summary>
+        /// Date when this ownership info took effect
+        /// </summary>
+        [FieldConverter(ConverterKind.Date, "M/d/yyyy")] 
+        public DateTime? OwnerDate;
+
+        /// <summary>
         /// The type of ownership for this parcel
         /// </summary>
         public string OwnerType;
-        /// <summary>
-        /// Date when this ownership info took effect
-        /// </summary>
-        [FieldConverter(ConverterKind.Date, "MM/dd/yyyy")] 
-        public DateTime? OwnerDate;
+
         /// <summary>
         /// Type of ownership
         /// </summary>

--- a/csharp/Urban.DCP.Web/clientsrc/pdp/css/pdp-app.css
+++ b/csharp/Urban.DCP.Web/clientsrc/pdp/css/pdp-app.css
@@ -60,6 +60,10 @@
     overflow-x: auto;
 }
 
+#pdp-child-display {
+    clear: both;
+}
+
 #pdp-child-display td, #pdp-child-display th {
     padding: 10px;
     text-align: left;

--- a/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-widget-pdb-longview.js
+++ b/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-widget-pdb-longview.js
@@ -231,12 +231,12 @@
                         '<div class="pdp-longview-street"></div>' +
                         '<a id="pdp-download-report" style="display=none;" href="javascript:void(0)">' + _options.linkText + '</a>' + 
                         '<table id="pdp-longview-table" class="pdp-longview-list"></table>' +
-                        '<div id="pdp-child-display"></div>' +
                     '</div>' +
                     '<div id="pdp-longview-right">' +
                         '<div id="pdp-longview-comments"></div>' +
                         '<div class="pdp-longview-comment-form"></div>' +
                     '</div>' +
+                    '<div id="pdp-child-display"></div>' +
                 '</div>');
             _$street = $('.pdp-longview-street', _$container);
 


### PR DESCRIPTION
- DC switched the order of name & date in their source files
- Be less strict about # of digits in date parts
- Better display of child record, use full width
