### PR TITLE
Allow only primary fields in the column selector

### DIFF
--- a/csharp/Urban.DCP.Data/PDB/PdbCriteriaAttributeMetadata.cs
+++ b/csharp/Urban.DCP.Data/PDB/PdbCriteriaAttributeMetadata.cs
@@ -72,6 +72,10 @@ namespace Urban.DCP.Data.PDB
         /// The collection of values that are allowed for this attribute.
         /// </summary>
         public List<IDictionary<string, object>> Values;
+        /// <summary>
+        /// Primary table fields can be shown in table views (1:1 relationship with property)
+        /// </summary>
+        public bool CanShowInTable;
 
         /// <summary>
         /// This constructor copies the necessary fields off the attribute.
@@ -102,6 +106,7 @@ namespace Urban.DCP.Data.PDB
             ValType = attr.ValueType == null ? null : attr.ValueType.ToString();
             Values = legitValues;
             QueryName = attr.FilterName;
+            CanShowInTable = attr.InPrimaryTable;
         }
     }
 }

--- a/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-widget-column-selector.js
+++ b/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-widget-column-selector.js
@@ -39,7 +39,7 @@
                         _renderAttrs(obj.Attrs, $cat.children('ul.pdp-column-select-category'));
                     } else {
                         // Handle the attributes, if there is no Category or Name, we don't want the choice
-                        if(obj.Category && obj.Name){
+                        if(obj.Category && obj.Name && obj.CanShowInTable){
                             // This is a criteria attribute
                             $('<li rel="' + obj.CategoryOrder + '"><input type="checkbox" id="col-sel-'+obj.UID+'" /><label for="col-sel-'+obj.UID+'" class="pdp-pdb-column-label">'+obj.QueryName+'</label></li>').appendTo($target);
                         }


### PR DESCRIPTION
Child fields were not explicitly kept out of the table view, only by
convention of not giving them a "TableDisplayName".  The client
did not follow that convention, so added an explicit check to prevent
any child resources from becoming an option in the col picker.

Fixes #86
