### PR TITLE
Show all results on filter reset

### DIFF
--- a/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-pdb-search.js
+++ b/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-pdb-search.js
@@ -32,6 +32,7 @@
             //Clear the criteria and results
             $('#pdp-pdb-button-reset').click(function(){
                 $(_options.bindTo).trigger('pdp-criteria-reset');
+                $(_options.bindTo).trigger('pdp-data-force-update');
             });
         });
 


### PR DESCRIPTION
All results are shown on page load with no filters loaded, so resetting
the filters should also show all results again.

Fixes #89
