### PR TITLE
When attribute has no display name, do not show it

### DIFF
--- a/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-map.js
+++ b/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-map.js
@@ -164,7 +164,8 @@
                     // Locate the Property Name for our caption, which may be null and mark it to not show in list
                     if (attr.Name === 'Project Name') {
                         caption = record[i] || '';
-                    } else if (attr.ShortOrder && (_options.hideNoValues ? (record[i] || record[i] === 0) : true) ) {
+                    } else if (attr.ShortOrder && attr.Name
+                            && (_options.hideNoValues ? (record[i] || record[i] === 0) : true)) {
                         // Show this attribute value (unless hideNoValues = true and there is no value)
                         label = '<label class="pdp-shortview-label">' + attr.Name + ':</label>';
                         value = '<label class="pdp-shortview-value">' + P.Util.renderers[attr.ValType](record[i]) + '</label>';

--- a/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-widget-pdb-longview.js
+++ b/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-widget-pdb-longview.js
@@ -68,7 +68,8 @@
                 }
 
                 // Show this attribute value (unless hideNoValues = true and there is no value)
-                if (show && attr.LongOrder && (_options.hideNoValues ? record[i] || record[i] === 0 : true) ) {
+                if (show && attr.LongOrder && attr.Name
+                        && (_options.hideNoValues ? record[i] || record[i] === 0 : true)) {
                     label = '<label class="pdp-longview-label">' + attr.Name + ':</label>';
                     if ($.isArray(record[i])){
                         // For this list, we just want to comma delimit the array

--- a/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-widget-table.js
+++ b/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-widget-table.js
@@ -404,7 +404,7 @@
         
             _curColVisibility = [];
             $.each(_curResponse.Attrs, function(i, obj) {
-                _curColVisibility.push(obj.OnByDefault);
+                _curColVisibility.push(obj.OnByDefault && obj.Name);
             });
         });
         


### PR DESCRIPTION
This was implied in the documentation, but not implemented everywhere.
Now when no displayName is set, it won't show up in table (default or
not), popup or longview.

Fixes #82
