### PR TITLE
Respect LongOrder and ShortOrder values

### DIFF
--- a/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-map.js
+++ b/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-map.js
@@ -159,8 +159,9 @@
                 _popupPropertyIdByIndex.push(id);
                 _popupIndexByPropertyId[id] = j;
                 
-                $.each(data.Attrs, function(i, attr) {
+                $.each(P.Util.sortByWithIndex(data.Attrs, "ShortOrder"), function(index, attr) {
                     show = true;
+                    var i = attr.index;
                     // Locate the Property Name for our caption, which may be null and mark it to not show in list
                     if (attr.Name === 'Project Name') {
                         caption = record[i] || '';

--- a/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-util.js
+++ b/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-util.js
@@ -208,6 +208,15 @@
         },
         trackMetric: function(category, action, label, value){
             _gaq.push(['_trackEvent', category, action, label, value]);
+        },
+        sortByWithIndex: function(attributeList, sortKey) {
+            // Sort by specified attribute, and track the
+            // original index of the object in the list to read the record
+            // values by the correct index.
+            return _.chain(attributeList)
+                .map(function(attr, i) { return _.extend(attr, { index: i }); })
+                .sortBy(sortKey)
+                .value();
         }
     };
 }(PDP));

--- a/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-widget-pdb-longview.js
+++ b/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-widget-pdb-longview.js
@@ -45,8 +45,9 @@
                 v;
                 
             // Loop through each attribute to see if it should be included in the long view
-            // and build a list of label/values
-            $.each(attrs, function(i, attr) {
+            // and build a list of label/values.  
+            $.each(P.Util.sortByWithIndex(attrs, "LongOrder"), function(index, attr) {
+                var i = attr.index;
                 show = true;
                 // Locate the Property Name for our caption, which may be null and mark it to not show in list
                 if (attr.UID === 'Proj_Name') {


### PR DESCRIPTION
"More Details" and small map popup did not respect the sort order
specified in the attribute configuration.

Fixes #83 
