### PR TITLE
String, date and bool marked for Optional Quotes

### DIFF
--- a/csharp/Urban.DCP.Data/PDB/PdbAttribute.cs
+++ b/csharp/Urban.DCP.Data/PDB/PdbAttribute.cs
@@ -20,33 +20,39 @@ namespace Urban.DCP.Data.PDB
         /// <summary>
         /// Tells what kind of data the attribute is for.  Currently only properties are supported.
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public PdbEntityType EntityType;
 
         /// <summary>
         /// The column name within the primary table or "AttrName"
         /// within the secondary table.  Known as "Attribute" in the table.
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string Name;
 
         /// <summary>
         /// Is this a property that can be queried on?
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public bool AllowFiltering;
 
         /// <summary>
         /// What order should this attribute be displayed in for the criteria list within the 
         /// category and subcategory?
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string FilterAttrOrder;
 
         /// <summary>
         /// Used for grouping related properties.
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string Category;
 
         /// <summary>
         /// What order should this attribute's category be displayed in for the criteria list?
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string FilterCatOrder;
 
         /// <summary>
@@ -54,35 +60,41 @@ namespace Urban.DCP.Data.PDB
         /// Corresponds to "Grouping".
         /// </summary>
         [FieldConverter(typeof(EmptyStringToNull))]
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string SubCategory;
 
         /// <summary>
         /// What order should this attribute's subcategory be displayed in for the criteria list
         /// within the category?
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string FilterSubCatOrder;
 
         /// <summary>
         /// Is this attribute in the primary, or secondary, table?
         /// Corresponds to "IsNative".
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public bool InPrimaryTable;
 
         /// <summary>
         /// The name that will be displayed to the user when display (table).
         /// </summary>
         [FieldConverter(typeof(EmptyStringToNull))]
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string DisplayName;
 
         /// <summary>
         /// The name that will be displayed to the user when querying.
         /// </summary>
         [FieldConverter(typeof(EmptyStringToNull))]
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string FilterName;
 
         /// <summary>
         /// A verbose description that can be offered to the user.
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string Description;
 
         /// <summary>
@@ -91,11 +103,13 @@ namespace Urban.DCP.Data.PDB
         /// or "range" (min / max controls) etc.
         /// Corresponds to "AttributeType".
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public PdbUiType? UiType;
 
         /// <summary>
         /// Money, year, text, etc.
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public PdbValueType? ValueType;
 
         /// <summary>
@@ -112,17 +126,20 @@ namespace Urban.DCP.Data.PDB
         /// <summary>
         /// Is this a property that can be grouped by when querying?
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public bool AllowGroupBy;
 
         /// <summary>
         /// The role the user must have in order to view / query / etc this attribute.
         /// Corresponds to "SecurityLevel"
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public SecurityRole? RequiredRole;
 
         /// <summary>
         /// In result grids, is this attribute shown by default?
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public bool? ShowByDefault;
 
         /// <summary>
@@ -130,6 +147,7 @@ namespace Urban.DCP.Data.PDB
         /// Table view?
         /// </summary>
         [FieldConverter(typeof(EmptyStringToNull))]
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string TableViewOrder;
 
         /// <summary>
@@ -137,6 +155,7 @@ namespace Urban.DCP.Data.PDB
         /// "Short" (brief) view?
         /// </summary>
         [FieldConverter(typeof(EmptyStringToNull))]
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string ShortViewOrder;
 
         /// <summary>
@@ -144,12 +163,14 @@ namespace Urban.DCP.Data.PDB
         /// "Long" (Detailed) view?
         /// </summary>
         [FieldConverter(typeof(EmptyStringToNull))]
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string LongViewOrder;
 
         /// <summary>
         /// This may be removed, but it is used for if we have a "basic" and "advanced"
         /// query screen.
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public PdbDifficulty? Difficulty;
 
 

--- a/csharp/Urban.DCP.Data/Uploadable/Parcel.cs
+++ b/csharp/Urban.DCP.Data/Uploadable/Parcel.cs
@@ -9,14 +9,17 @@ namespace Urban.DCP.Data.Uploadable
     public class Parcel: IDisplaySortable
     {
 
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string NlihcId;
         /// <summary>
         /// Parcel record Identifier
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string Ssl;
         /// <summary>
         /// Res/Non Res, single family, etc
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string ParcelType;
         /// <summary>
         /// Parcel owner name
@@ -27,11 +30,13 @@ namespace Urban.DCP.Data.Uploadable
         /// Date when this ownership info took effect
         /// </summary>
         [FieldConverter(ConverterKind.Date, "M/d/yyyy")] 
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public DateTime? OwnerDate;
 
         /// <summary>
         /// The type of ownership for this parcel
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string OwnerType;
 
         /// <summary>

--- a/csharp/Urban.DCP.Data/Uploadable/Project.cs
+++ b/csharp/Urban.DCP.Data/Uploadable/Project.cs
@@ -19,62 +19,97 @@ namespace Urban.DCP.Data.Uploadable
     public class Project
     {
 
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string Id;
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string Status;
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string Subsidized;
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string Category;
-        [FieldQuoted('"', QuoteMode.OptionalForRead)] public string Name;
-        [FieldQuoted('"', QuoteMode.OptionalForRead)] public string Address;
+        [FieldQuoted('"', QuoteMode.OptionalForRead)]
+        public string Name;
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
+        public string Address;
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string City;
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string State;
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string Zip;
         public int? TotalUnits;
         public int? MinAssistedUnits;
         public int? MaxAssistedUnits;
         public int? BuildingCount; 
-        [FieldConverter(ConverterKind.Date, "MM/dd/yyyy")] public DateTime? OwnershipEffectiveDate;
+
+        [FieldConverter(ConverterKind.Date, "MM/dd/yyyy")] 
+        [FieldQuoted('"', QuoteMode.OptionalForRead)]
+        public DateTime? OwnershipEffectiveDate;
 
         [FieldQuoted('"', QuoteMode.OptionalForRead)] public string OwnerName;
         [FieldQuoted('"', QuoteMode.OptionalForRead)] public string OwnerType;
         [FieldQuoted('"', QuoteMode.OptionalForRead)] public string ManagerName;
         [FieldQuoted('"', QuoteMode.OptionalForRead)] public string ManagerType;
 
-        [FieldConverter(ConverterKind.Date, "MM/dd/yyyy")] public DateTime? EarliestSubsidyEnd;
+        [FieldConverter(ConverterKind.Date, "MM/dd/yyyy")] 
+        [FieldQuoted('"', QuoteMode.OptionalForRead)]
+        public DateTime? EarliestSubsidyEnd;
 
-        [FieldConverter(ConverterKind.Date, "MM/dd/yyyy")] public DateTime? LatestSubsidyEnd;
+        [FieldConverter(ConverterKind.Date, "MM/dd/yyyy")]
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
+        public DateTime? LatestSubsidyEnd;
+
         /// <summary>
         /// A display version of the Agencies who are providing subsidy
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string Agencies;
         /// <summary>
         /// A display version of the Portfolios of subsidy programs in this project
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string Portfolios;
 
         // The follow are Statuses and Year begun for various specific subsidy programs
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string HudFinancialStatus;
         public int? HudFinancialYear;
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string HudPbraStatus;
         public int? HudPbraYear;
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string LihtcStatus;
         public int? LihtcYear;
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string HptfStatus;
         public int? HptfYear;
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string IzAduStatus;
         public int? IzAduYear;
         
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string Ward;
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string Anc; // Advisory Neighborhood Commission
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string PoliceArea;
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string ClusterId;
-        [FieldQuoted('"', QuoteMode.OptionalForRead)] public string ClusterName;
-        [FieldNotInFile] public string ClusterCombo;
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
+        public string ClusterName;
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
+        [FieldNotInFile] 
+        public string ClusterCombo;
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string CensusTract;
         public double? X;
         public double? Y;
         public double? Lat;
         public double? Lon;
-        [FieldQuoted('"', QuoteMode.OptionalForRead)] public string StreetViewUrl;
+        [FieldQuoted('"', QuoteMode.OptionalForRead)]
+        public string StreetViewUrl;
+
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string ImageUrl;
 
     }

--- a/csharp/Urban.DCP.Data/Uploadable/Reac.cs
+++ b/csharp/Urban.DCP.Data/Uploadable/Reac.cs
@@ -9,15 +9,18 @@ namespace Urban.DCP.Data.Uploadable
     public class Reac: IDisplaySortable 
     {
 
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string NlihcId;
         /// <summary>
         /// Date REAC score was given
         /// </summary>
         [FieldConverter(ConverterKind.Date, "MM/dd/yyyy")] 
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public DateTime ScoreDate;
         /// <summary>
         /// Total REAC Score (ScoreNum + ScoreLetter)
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string Score;
         /// <summary>
         /// Number componenet of score
@@ -26,6 +29,7 @@ namespace Urban.DCP.Data.Uploadable
         /// <summary>
         /// Letter component of score
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string ScoreLetter;
 
         public string GetSortField()

--- a/csharp/Urban.DCP.Data/Uploadable/RealPropertyEvent.cs
+++ b/csharp/Urban.DCP.Data/Uploadable/RealPropertyEvent.cs
@@ -9,20 +9,24 @@ namespace Urban.DCP.Data.Uploadable
     public class RealPropertyEvent: IDisplaySortable
     {
 
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string NlihcId;
         /// <summary>
         /// Parcel record Identifier
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string Ssl;
         /// <summary>
         /// Date when this event was recorded
         /// </summary>
         [FieldConverter(ConverterKind.Date, "MM/dd/yyyy")] 
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public DateTime? EventDate;
         /// <summary>
         /// Key for type of event: Property Sale, Foreclosure Notice,
         ///  Foreclosure Outcome
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string EventType;
         /// <summary>
         /// Detailed description of the event type

--- a/csharp/Urban.DCP.Data/Uploadable/Subsidy.cs
+++ b/csharp/Urban.DCP.Data/Uploadable/Subsidy.cs
@@ -14,22 +14,27 @@ namespace Urban.DCP.Data.Uploadable
     [IgnoreFirst(1)]
     public class Subsidy: IDisplaySortable 
     {
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string NlihcId;
         /// <summary>
         /// Description of the status of the project for this program
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string SubsidyActive;
         /// <summary>
         /// The name of the subsidy program
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string ProgramName;
         /// <summary>
         /// Unknown
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string SubsidyInfo;
         /// <summary>
         /// The contract number for this project and this program
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string ContractNumber;
         /// <summary>
         /// The numbers of assisted units provided for under this program
@@ -39,24 +44,29 @@ namespace Urban.DCP.Data.Uploadable
         /// The date which this project entered active status for this program
         /// </summary>
         [FieldConverter(ConverterKind.Date, "MM/dd/yyyy")] 
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public DateTime? ProgramActiveStart;
         /// <summary>
         /// The date which this project leaves active status for this program
         /// </summary>
         [FieldConverter(ConverterKind.Date, "MM/dd/yyyy")] 
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public DateTime? ProgramActiveEnd;
         /// <summary>
         /// The source program for this program
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string SubsidyInfoSource;
         /// <summary>
         /// Notes on this projects participation in the program
         /// </summary>
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public string SubsidyNotes;
         /// <summary>
         /// Date when this program status was updated
         /// </summary>
         [FieldConverter(ConverterKind.Date, "MM/dd/yyyy")] 
+        [FieldQuoted('"', QuoteMode.OptionalForRead)] 
         public DateTime? SubsidyUpdate;
 
         public string GetSortField()


### PR DESCRIPTION
When Excel saves a CSV, it puts in quotes for all non-numeric cells.
Add attributes to the uploadables to allow for the presence of quotes
even when they weren't expected or needed.

Fixes #94 
