### PR TITLE
Prevent unneed popup line wraps

### DIFF
--- a/csharp/Urban.DCP.Web/clientsrc/pdp/css/pdp-app.css
+++ b/csharp/Urban.DCP.Web/clientsrc/pdp/css/pdp-app.css
@@ -421,7 +421,7 @@ html, body {
     font-size: 12px!important;
     color: #C88C94;
     font-weight: 600!important;
-    width: 300px;  
+    width: 150px;  
     display: inline-block;
     vertical-align: top;
     text-align: right;
@@ -431,7 +431,7 @@ html, body {
     font-size: 12px!important;
     color: #0F4038;
     font-weight: 600!important;
-    width: 75px;
+    width: 135px;
     vertical-align: top;
     text-align: left;
     display: inline-block;


### PR DESCRIPTION
The padding between label and value was so excessive that
line breaks sometimes occurred when not needed.

Fixes #84 
