### PR TITLE
Restrict CSV download to Network users

### DIFF
--- a/csharp/Urban.DCP.Data/User.cs
+++ b/csharp/Urban.DCP.Data/User.cs
@@ -127,6 +127,16 @@ namespace Urban.DCP.Data
             return RolesList.Contains(SecurityRole.limited);
         }
 
+        /// <summary>
+        /// Is the user authorized to export as csv?  Must be confirmed and
+        /// either Network or SysAdmin role
+        /// </summary>
+        /// <returns></returns>
+        public bool CanExport()
+        {
+            return EmailConfirmed && (IsNetworked() || IsSysAdmin());
+        }
+
         public override string ToString()
         {
             return Name;

--- a/csharp/Urban.DCP.Handlers/LoginHandler.cs
+++ b/csharp/Urban.DCP.Handlers/LoginHandler.cs
@@ -33,6 +33,7 @@ namespace Urban.DCP.Handlers
                                     user.Name,
                                     Admin = user.IsSysAdmin(),
                                     Limited = user.IsLimited(),
+                                    Networked = user.IsNetworked(),
                                     user.EmailConfirmed
                                 }));
                     return;

--- a/csharp/Urban.DCP.Handlers/PropertiesHandler.cs
+++ b/csharp/Urban.DCP.Handlers/PropertiesHandler.cs
@@ -43,9 +43,9 @@ namespace Urban.DCP.Handlers
             User authUser = UserHelper.GetUser(context.User.Identity.Name);
             if (csv)
             {
-                if (authUser == null || !authUser.EmailConfirmed)
+                if (authUser == null || !authUser.CanExport())
                 {
-                    throw new AzaveaWebNotAuthorizedException("Insuffient privileges (User must have email confirmed to export csv.)");
+                    throw new AzaveaWebNotAuthorizedException("Insuffient privileges (Network user must have email confirmed to export csv.)");
                 }
             }
 

--- a/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-pdb-results.js
+++ b/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-pdb-results.js
@@ -269,7 +269,10 @@
 
         var _setupExtras = Azavea.tryCatch('set up extra features that req special auth', function (user) {
             if (user && user.EmailConfirmed) {
-                $(_options.bindTo).trigger('pdp-enable-extras');
+                // Broadcast that extra features are enabled because a confirmed
+                // user is logged in.  Supply the user object in case more fine
+                // grained control is need for a particular widget
+                $(_options.bindTo).trigger('pdp-enable-extras', user);
             } else {
                 $(_options.bindTo).trigger('pdp-disable-extras');
             }

--- a/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-widget-export.js
+++ b/csharp/Urban.DCP.Web/clientsrc/pdp/pdp-widget-export.js
@@ -36,8 +36,11 @@
                 $container.hide();
             });
 
-            $(_options.bindTo).bind('pdp-enable-extras', function () {
-                _extrasEnabled = true;
+            $(_options.bindTo).bind('pdp-enable-extras', function (evt, user) {
+                // Export should be enabled only for 'network' and 'sysadmin'
+                if (user && (user.Networked || user.Admin )) {
+                    _extrasEnabled = true;
+                }
             });
 
             $(_options.bindTo).bind('pdp-disable-extras', function () {


### PR DESCRIPTION
Previously, a user with a confirmed email address could download CSV
results but that feature is now restricted to Network and Admin users.

#### Testing
##### Unauthorized Users
Test both that the "Export as CSV" link is not shown (on Table tab) to unauthorized users and that actual requests are failed for those users.
* Unlogged in users and limited user (`testlimited`: `asdfasdf`) don't see link on table
* Unlogged in and limited user cannot make CSV request:
http://localhost:1318/handlers/properties.ashx?csv=true&pagesize=-1&page=-1&criteria=%5B%5D&sortby=-1&groupby=%5B%5D

##### Authorized User
* Network User can see CSV link on table tab, the link executes correctly (`test`: `asdfasdf`)

Connects #112 